### PR TITLE
Update gemspec, rewrite specs in Rspec3 syntax

### DIFF
--- a/here_places.gemspec
+++ b/here_places.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features|helper)/})
   gem.require_paths = ["lib"]
-  gem.add_development_dependency 'rspec', '~>2.1'
+  gem.add_development_dependency 'rspec', '~>3.1'
   gem.add_development_dependency 'fakeweb', '~>1.3'
-  gem.add_dependency 'faraday', '~>0.8.4'
+  gem.add_dependency 'faraday', '~>0.9.1'
 end

--- a/lib/here_places.rb
+++ b/lib/here_places.rb
@@ -13,3 +13,18 @@ require_relative './here_places/suggest'
 # /places/{placeId}
 # /suggest?q=...&[at=...]
 # /categories/places?[at=...]
+
+module HerePlaces
+  def self.set_keys(app_id, app_code)
+    @@app_id = app_id
+    @@app_code = app_code
+  end
+
+  def self.app_id
+    @@app_id
+  end
+
+  def self.app_code
+    @@app_code
+  end
+end

--- a/lib/here_places/base.rb
+++ b/lib/here_places/base.rb
@@ -7,7 +7,7 @@ module HerePlaces
 
     def initialize(log=false)
       @log = log
-      setup()
+      setup
     end
     
     def setup
@@ -21,8 +21,8 @@ module HerePlaces
     def api(url_fragment, data={})
       result = @conn.get do |req|
         req.url url_fragment
-        req.params['app_id'] = HerePlaces.app_id
         req.params['app_code'] = HerePlaces.app_code
+        req.params['app_id']   = HerePlaces.app_id
         data.each do |key,value|
           req.params[key] = value
         end
@@ -35,18 +35,5 @@ module HerePlaces
         parsed_result
       end
     end
-  end
-
-  def self.set_keys(app_id, app_code)
-    @@app_id = app_id
-    @@app_code = app_code
-  end
-
-  def self.app_id
-    @@app_id
-  end
-
-  def self.app_code
-    @@app_code
   end
 end

--- a/spec/category_spec.rb
+++ b/spec/category_spec.rb
@@ -1,18 +1,15 @@
 require 'spec_helper'
 
 describe HerePlaces::Category do
-  before(:each) do
-    app_id = 'APP_ID'
-    app_code = 'APP_CODE'
-    @data = {test: 'stuff'}
-    @h = HerePlaces::Category.new(app_id, app_code)
-    @h.stub!(:api)
-  end
+  let(:object) { described_class.new }
+  let(:data) { { test: 'stuff' } }
 
   it 'responds correctly to places method and delegates to the api call' do
     resource_url = "#{API_PREFIX}/categories/places"
-    @h.should respond_to(:places)
-    @h.should_receive(:api).with(resource_url, @data)
-    @h.places(@data)
+    
+    expect(object).to respond_to(:places)
+    expect(object).to receive(:api).with(resource_url, data)
+
+    object.places(data)
   end
 end

--- a/spec/discover_spec.rb
+++ b/spec/discover_spec.rb
@@ -1,20 +1,17 @@
 require 'spec_helper'
 
 describe HerePlaces::Discover do
-  before(:each) do
-    app_id = 'APP_ID'
-    app_code = 'APP_CODE'
-    @data = {test: 'stuff'}
-    @h = HerePlaces::Discover.new(app_id, app_code)
-    @h.stub!(:api)
-  end
+  let(:object) { described_class.new }
+  let(:data) { { test: 'stuff' } }
 
   %w(search explore here).each do |meth|
     it "responds correctly to #{meth} and delegates to the api call" do
       resource_url = "#{API_PREFIX}/discover/#{meth}"
-      @h.should respond_to(meth.to_sym)
-      @h.should_receive(:api).with(resource_url, @data)
-      @h.send(meth.to_sym, @data)
+
+      expect(object).to respond_to(meth)
+      expect(object).to receive(:api).with(resource_url, data)
+
+      object.send(meth.to_sym, data)
     end
   end
 end

--- a/spec/place_spec.rb
+++ b/spec/place_spec.rb
@@ -1,18 +1,15 @@
 require 'spec_helper'
 
 describe HerePlaces::Place do
-  before(:each) do
-    app_id = 'APP_ID'
-    app_code = 'APP_CODE'
-    @id = '123asdfa'
-    @h = HerePlaces::Place.new(app_id, app_code)
-    @h.stub!(:api)
-  end
+  let(:object) { described_class.new }
+  let(:id) { '123asdfa' }
 
   it 'responds correctly to places method and delegates to the api call' do
-    resource_url = "#{API_PREFIX}/places/#{@id}"
-    @h.should respond_to(:places)
-    @h.should_receive(:api).with(resource_url)
-    @h.places(@id)
+    resource_url = "#{API_PREFIX}/places/#{id}"
+
+    expect(object).to respond_to(:places)
+    expect(object).to receive(:api).with(resource_url)
+
+    object.places(id)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,3 +6,9 @@ require 'here_places'
 
 BASE_URL = 'http://places.nlp.nokia.com/'
 API_PREFIX = 'places/v1'
+
+RSpec.configure do |config|
+  config.before(:all) do
+    HerePlaces.set_keys('APP_ID', 'APP_CODE')
+  end
+end

--- a/spec/suggest_spec.rb
+++ b/spec/suggest_spec.rb
@@ -1,18 +1,15 @@
 require 'spec_helper'
 
 describe HerePlaces::Suggest do
-  before(:each) do
-    app_id = 'APP_ID'
-    app_code = 'APP_CODE'
-    @data = {test: 'stuff'}
-    @h = HerePlaces::Suggest.new(app_id, app_code)
-    @h.stub!(:api)
-  end
+  let(:object) { described_class.new }
+  let(:data) { { test: 'stuff' } }
 
   it 'responds correctly to suggest method and delegates to the api call' do
     resource_url = "#{API_PREFIX}/suggest"
-    @h.should respond_to(:suggest)
-    @h.should_receive(:api).with(resource_url, @data)
-    @h.suggest(@data)
+
+    expect(object).to respond_to(:suggest)
+    expect(object).to receive(:api).with(resource_url, data)
+
+    object.suggest(data)
   end
 end


### PR DESCRIPTION
Update gemspec because of old `faraday` dependency.
Update `rspec` and rewrited specs for newer syntax.